### PR TITLE
Use findInArray method to support IE11

### DIFF
--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -27,6 +27,7 @@ import {
   Subscriptions as SubscriptionsDef,
 } from '../api/subscriptions';
 import {addQueryParam, parseQueryString} from './url';
+import {findInArray} from './object';
 import {getLanguageCodeFromElement, msg} from './i18n';
 import {parseJson} from './json';
 import {setImportantStyles} from './style';
@@ -464,17 +465,16 @@ export class GaaMeteringRegwall {
 
     for (let i = 0; i < ldJsonElements.length; i++) {
       const ldJsonElement = ldJsonElements[i];
-      let ldJson =
-        /** @type {?{ publisher: ?{ name: string } } | ?{ publisher: ?{ name: string } }[]} */ (
-          parseJson(ldJsonElement.textContent)
-        );
+      let ldJson = /** @type {*} */ (parseJson(ldJsonElement.textContent));
 
       if (!Array.isArray(ldJson)) {
         ldJson = [ldJson];
       }
 
-      const publisherName = ldJson.find((entry) => entry?.publisher?.name)
-        ?.publisher.name;
+      const publisherName = findInArray(
+        ldJson,
+        (entry) => entry?.publisher?.name
+      )?.publisher.name;
 
       if (publisherName) {
         return publisherName;


### PR DESCRIPTION
This PR updates https://github.com/subscriptions-project/swg-js/pull/1762 to pass the `check`

IE11 [doesn't support](https://caniuse.com/array-find) the Array's `find` method, so we use this `findInArray` method to be safe

Merging this PR should update your `swg-js` PR automatically